### PR TITLE
Fix import issue

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module gpt-3-encoder
+module github.com/samber/go-gpt-3-encode
 
 go 1.18
 


### PR DESCRIPTION
It seems the issue of this not being importable is through the improper module name that was the problem whenever the project was started. It was created with the command of "go mod init gpt-3-encoder" but the problem now is that it doesn't follow the entire github url for importing.